### PR TITLE
Made the bounding box sizes used for COCO metrics configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ These three metrics, also referred to as AP Across Scales, apply the AP@[.5,.05:
 
 When evaluating objects of a given size, objects of the other sizes (both ground-truth and predicted) are not considered in the evaluation. This metric is also part of the COCO evaluation dataset.
 
+When the evaluation is done in other settings, it is possible to use other values for small, medium and large bounding boxes. The lower bounds for the size categories can be given as command line parameters:
+
+`python run.py --small <lower bound, default 0> --medium <lower bound, default 32> --large <lower bound, default 96> `
+
 
 ## **Spatio-Temporal Tube Average Precision (STT-AP)**
 When dealing with videos, one may be interested in evaluating the model performance at  video level, i.e., whether the object was detected in the video as a whole. This metric is an extension of the AP metric that integrates spatial and temporal localizations; it is concise, yet expressive.

--- a/run.py
+++ b/run.py
@@ -2,15 +2,21 @@
 # python run.py
 
 import sys
+import argparse
 
 from PyQt5 import QtWidgets
 from src.ui.run_ui import Main_Dialog
 from src.ui.splash import Splash_Dialog
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog='Open-Source Toolbox for Object Detection Metrics')
+    parser.add_argument('--small', type=int, default=None, help='The lower bound for small boxes')
+    parser.add_argument('--medium', type=int, default=None, help='The lower bound for medium boxes')
+    parser.add_argument('--large', type=int, default=None, help='The lower bound for large boxes')
+    args = parser.parse_args()
     app = QtWidgets.QApplication(sys.argv)
 
-    ui = Main_Dialog()
+    ui = Main_Dialog(coco_sizes=(('small', args.small), ('medium', args.medium), ('large', args.large)))
     ui.show()
 
     splash = Splash_Dialog()

--- a/src/ui/details.py
+++ b/src/ui/details.py
@@ -6,11 +6,12 @@ import matplotlib.pyplot as plt
 from PyQt5.QtWidgets import QFileDialog, QMainWindow
 from src.bounding_box import BoundingBox
 from src.ui.details_ui import Ui_Dialog as Details_UI
-from src.utils import general_utils
+from src.ui.ui_utils import show_image_in_qt_component
 from src.utils.enumerators import BBType
-from src.utils.general_utils import (add_bb_into_image, get_files_dir,
+from src.utils.general_utils import (add_bb_into_image, plot_bb_per_classes,
+                                     get_files_dir,
                                      remove_file_extension,
-                                     show_image_in_qt_component)
+                                     get_file_name_only)
 
 
 class Details_Dialog(QMainWindow, Details_UI):
@@ -110,7 +111,7 @@ class Details_Dialog(QMainWindow, Details_UI):
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         # Get bounding boxes of the loaded image
         img_name = self.image_files[self.selected_image_index]
-        img_name = general_utils.get_file_name_only(img_name)
+        img_name = get_file_name_only(img_name)
         # Add bounding boxes depending if the item is checked
         if self.chb_gt_bb.isChecked() and self.gt_annotations is not None:
             bboxes = BoundingBox.get_bounding_boxes_by_image_name(self.gt_annotations, img_name)
@@ -139,10 +140,10 @@ class Details_Dialog(QMainWindow, Details_UI):
 
     def btn_plot_bb_per_classes_clicked(self):
         # dict_bbs_per_class = BoundingBox.get_amount_bounding_box_all_classes(gt_bbs, reverse=True)
-        general_utils.plot_bb_per_classes(self.bb_per_class,
-                                          horizontally=False,
-                                          rotation=90,
-                                          show=True)
+        plot_bb_per_classes(self.bb_per_class,
+                            horizontally=False,
+                            rotation=90,
+                            show=True)
         # plt.close()
         # plt.bar(self.bb_per_class.keys(), self.bb_per_class.values())
         # plt.xlabel('classes')

--- a/src/ui/ui_utils.py
+++ b/src/ui/ui_utils.py
@@ -1,0 +1,20 @@
+from PyQt5 import QtCore, QtGui
+import numpy as np
+
+
+def image_to_pixmap(image):
+    image = image.astype(np.uint8)
+    if image.shape[2] == 4:
+        qformat = QtGui.QImage.Format_RGBA8888
+    else:
+        qformat = QtGui.QImage.Format_RGB888
+
+    image = QtGui.QImage(image.data, image.shape[1], image.shape[0], image.strides[0], qformat)
+    # image= image.rgbSwapped()
+    return QtGui.QPixmap(image)
+
+
+def show_image_in_qt_component(image, label_component):
+    pix = image_to_pixmap((image).astype(np.uint8))
+    label_component.setPixmap(pix)
+    label_component.setAlignment(QtCore.Qt.AlignCenter)

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -4,7 +4,6 @@ import os
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
-from PyQt5 import QtCore, QtGui
 from src.utils.enumerators import BBFormat
 
 
@@ -139,24 +138,6 @@ def get_files_dir(directory, extensions=['*']):
 
 def remove_file_extension(filename):
     return os.path.join(os.path.dirname(filename), os.path.splitext(filename)[0])
-
-
-def image_to_pixmap(image):
-    image = image.astype(np.uint8)
-    if image.shape[2] == 4:
-        qformat = QtGui.QImage.Format_RGBA8888
-    else:
-        qformat = QtGui.QImage.Format_RGB888
-
-    image = QtGui.QImage(image.data, image.shape[1], image.shape[0], image.strides[0], qformat)
-    # image= image.rgbSwapped()
-    return QtGui.QPixmap(image)
-
-
-def show_image_in_qt_component(image, label_component):
-    pix = image_to_pixmap((image).astype(np.uint8))
-    label_component.setPixmap(pix)
-    label_component.setAlignment(QtCore.Qt.AlignCenter)
 
 
 def get_files_recursively(directory, extension="*"):


### PR DESCRIPTION
Earlier there were three predefined bounding box sizes: small, medium
and large for the COCO metrics. This commit makes the size and number
of intervals configurable. The aim is to make the metrics more useful
for other settings than the COCO benchmarks. Detailed changes:

- Made the bounds configurable in coco_evalotor.py. The default behaviour
  is unchanged.

- Enaled running metrics calulcations with PyQt5.

- Made the bounding box size categories configurable when running the GUI.
  The sizes for the categories small, medium and large can now be given as
  command line arguments.