### PR TITLE
Load images and annotations from the same folder

### DIFF
--- a/src/utils/converter.py
+++ b/src/utils/converter.py
@@ -319,12 +319,13 @@ def yolo2bb(annotations_path, images_dir, file_obj_names, bb_type=BBType.GROUND_
         all_classes = [line.replace('\n', '') for line in f]
     # Get annotation files in the path
     annotation_files = _get_annotation_files(annotations_path)
+    image_file_only = annotations_path == images_dir
     # Loop through each file
     for file_path in annotation_files:
         if not validations.is_yolo_format(file_path, bb_types=[bb_type]):
             continue
         img_name = os.path.basename(file_path)
-        img_file = general_utils.find_file(images_dir, img_name, match_extension=False)
+        img_file = general_utils.find_file(images_dir, img_name, match_extension=False, image_file_only=image_file_only)
         img_resolution = general_utils.get_image_resolution(img_file)
         if img_resolution is None:
             print(f'Warning: It was not possible to find the resolution of image {img_name}')

--- a/src/utils/converter.py
+++ b/src/utils/converter.py
@@ -319,13 +319,12 @@ def yolo2bb(annotations_path, images_dir, file_obj_names, bb_type=BBType.GROUND_
         all_classes = [line.replace('\n', '') for line in f]
     # Get annotation files in the path
     annotation_files = _get_annotation_files(annotations_path)
-    image_file_only = annotations_path == images_dir
     # Loop through each file
     for file_path in annotation_files:
         if not validations.is_yolo_format(file_path, bb_types=[bb_type]):
             continue
         img_name = os.path.basename(file_path)
-        img_file = general_utils.find_file(images_dir, img_name, match_extension=False, image_file_only=image_file_only)
+        img_file = general_utils.find_file(images_dir, img_name, match_extension=False, allowed_extensions=[".bmp", ".jpg", ".jpeg", ".png"])
         img_resolution = general_utils.get_image_resolution(img_file)
         if img_resolution is None:
             print(f'Warning: It was not possible to find the resolution of image {img_name}')

--- a/src/utils/converter.py
+++ b/src/utils/converter.py
@@ -266,7 +266,7 @@ def text2bb(annotations_path,
             img_size = None
             # If coordinates are relative, image size must be obtained in the img_dir
             if type_coordinates == CoordinatesType.RELATIVE:
-                img_path = general_utils.find_file(img_dir, img_filename, match_extension=False)
+                img_path = general_utils.find_image_file(img_dir, img_filename)
                 if img_path is None or os.path.isfile(img_path) is False:
                     print(
                         f'Warning: Image not found in the directory {img_path}. It is required to get its dimensions'
@@ -324,7 +324,7 @@ def yolo2bb(annotations_path, images_dir, file_obj_names, bb_type=BBType.GROUND_
         if not validations.is_yolo_format(file_path, bb_types=[bb_type]):
             continue
         img_name = os.path.basename(file_path)
-        img_file = general_utils.find_file(images_dir, img_name, match_extension=False, allowed_extensions=[".bmp", ".jpg", ".jpeg", ".png"])
+        img_file = general_utils.find_image_file(images_dir, img_name)
         img_resolution = general_utils.get_image_resolution(img_file)
         if img_resolution is None:
             print(f'Warning: It was not possible to find the resolution of image {img_name}')

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -181,6 +181,7 @@ def get_file_name_only(file_path):
     return os.path.splitext(os.path.basename(file_path))[0]
 
 
+# allowed_extensions is used only when match_extension=False
 def find_file(directory, file_name, match_extension=True, allowed_extensions=[]):
     if os.path.isdir(directory) is False:
         return None
@@ -188,12 +189,20 @@ def find_file(directory, file_name, match_extension=True, allowed_extensions=[])
         for f in files:
             f1 = os.path.basename(f)
             f2 = file_name
-            if not match_extension:
+            if match_extension:
+                match = f1 == f2
+            else:
                 f1 = os.path.splitext(f1)[0]
                 f2 = os.path.splitext(f2)[0]
-            if f1 == f2 and (len(allowed_extensions) == 0 or os.path.splitext(f)[-1].lower() in allowed_extensions):
+                f_ext = os.path.splitext(f)[-1].lower()
+                match = f1 == f2 and (len(allowed_extensions) == 0 or f_ext in allowed_extensions)
+            if match:
                 return os.path.join(dirpath, os.path.basename(f))
     return None
+
+
+def find_image_file(directory, file_name):
+    return find_file(directory, file_name, False, [".bmp", ".jpg", ".jpeg", ".png"])
 
 
 def get_image_resolution(image_file):

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -181,7 +181,7 @@ def get_file_name_only(file_path):
     return os.path.splitext(os.path.basename(file_path))[0]
 
 
-def find_file(directory, file_name, match_extension=True):
+def find_file(directory, file_name, match_extension=True, allowed_extensions=[]):
     if os.path.isdir(directory) is False:
         return None
     for dirpath, dirnames, files in os.walk(directory):
@@ -191,7 +191,7 @@ def find_file(directory, file_name, match_extension=True):
             if not match_extension:
                 f1 = os.path.splitext(f1)[0]
                 f2 = os.path.splitext(f2)[0]
-            if f1 == f2:
+            if f1 == f2 and (len(allowed_extensions) == 0 or os.path.splitext(f)[-1].lower() in extensions):
                 return os.path.join(dirpath, os.path.basename(f))
     return None
 

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -191,7 +191,7 @@ def find_file(directory, file_name, match_extension=True, allowed_extensions=[])
             if not match_extension:
                 f1 = os.path.splitext(f1)[0]
                 f2 = os.path.splitext(f2)[0]
-            if f1 == f2 and (len(allowed_extensions) == 0 or os.path.splitext(f)[-1].lower() in extensions):
+            if f1 == f2 and (len(allowed_extensions) == 0 or os.path.splitext(f)[-1].lower() in allowed_extensions):
                 return os.path.join(dirpath, os.path.basename(f))
     return None
 


### PR DESCRIPTION
### Problem description

This PR fixes an issue when the images and annotation files are stored in the same folder. Here is an example dataset causing problem: 3 images, the 3 corresponding annotation files and the `classes.txt` file all at the root folder of the dataset. 
```
.
├── 000000.jpg
├── 000000.txt
├── 000001.jpg
├── 000001.txt
├── 000002.jpg
├── 000002.txt
├── classes.txt
```
With the version in the `main` branch, some images might be skipped because https://github.com/rafaelpadilla/review_object_detection_metrics/blob/49a614a6ca59e39f2aecd085730cc2e4d30cd886/src/utils/general_utils.py#L186 relies on `os.walk` which iterates through the files of the specified folder in an arbitrary order (depending on the `python` version `os.walk` uses `os.listdir` or `os.scandir` but both of them returns files in an arbitrary order: official documentation https://docs.python.org/3/library/os.html#os.listdir, https://docs.python.org/3/library/os.html#os.scandir). It is then possible that when looking for `000001.jpg` for example, `000001.txt` is found first and because extensions are ignored in `find_file` when looking for the image file corresponding to an annotation file,  `000001.txt` is incorrectly returned. As it is not a valid image file, properties such as image resolution cannot be retrieved and thus the `000001` is skipped (e.g. https://github.com/rafaelpadilla/review_object_detection_metrics/blob/49a614a6ca59e39f2aecd085730cc2e4d30cd886/src/utils/converter.py#L329-L331).

### Proposed solution

This PR introduces a `find_image_file` function that can be used to find the corresponding image file given an annotation filename. It relies on a modified version of the `find_file` function which can be called with a list of allowed extensions when trying to match filenames. In  `find_image_file`, `find_file` is called with `allowed_extensions` set to a list of the most common image file extension `.bmp, .jpg, .jpeg, .png`.