### PR TITLE
Keep the focus on the splash screen

### DIFF
--- a/src/ui/splash.py
+++ b/src/ui/splash.py
@@ -9,7 +9,13 @@ class Splash_Dialog(QMainWindow, Splash_UI):
         self.setupUi(self)
         self.center_screen()
 
-        self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+        self.setWindowFlags(
+                QtCore.Qt.FramelessWindowHint |
+                QtCore.Qt.WindowStaysOnTopHint
+                )
+
+        self.btn_Close.setDefault(True)
+        self.btn_Close.setFocus()
 
     def center_screen(self):
         size = self.size()


### PR DESCRIPTION
Right now, the splash screen can stay in the background after start. It might be forgotten. Not a real issue, but not nice.
This PR keeps the window in the foreground and sets the focus on the close-button: The window can be closed by hitting "enter" after the app start.