### PR TITLE
fix: cast coordinates to int when moving window

### DIFF
--- a/src/ui/run_ui.py
+++ b/src/ui/run_ui.py
@@ -39,8 +39,8 @@ class Main_Dialog(QMainWindow, Main_UI):
     def center_screen(self):
         size = self.size()
         desktopSize = QtWidgets.QDesktopWidget().screenGeometry()
-        top = (desktopSize.height() / 2) - (size.height() / 2)
-        left = (desktopSize.width() / 2) - (size.width() / 2)
+        top = int((desktopSize.height() / 2) - (size.height() / 2))
+        left = int((desktopSize.width() / 2) - (size.width() / 2))
         self.move(left, top)
 
     def closeEvent(self, event):

--- a/src/ui/splash.py
+++ b/src/ui/splash.py
@@ -14,8 +14,8 @@ class Splash_Dialog(QMainWindow, Splash_UI):
     def center_screen(self):
         size = self.size()
         desktopSize = QtWidgets.QDesktopWidget().screenGeometry()
-        top = (desktopSize.height() / 2) - (size.height() / 2)
-        left = (desktopSize.width() / 2) - (size.width() / 2)
+        top = int((desktopSize.height() / 2) - (size.height() / 2))
+        left = int((desktopSize.width() / 2) - (size.width() / 2))
         self.move(left, top)
 
     def btn_close_clicked(self):


### PR DESCRIPTION
This pull request fixes a TypeError in the center_screen() function by casting coordinates to integers before passing them to self.move(). This prevents the widget positioning error in PyQt5 and improves cross-platform compatibility.